### PR TITLE
fix(evaluate): stop counting function declarations as global

### DIFF
--- a/evaluate.js
+++ b/evaluate.js
@@ -42,7 +42,9 @@ const STATS = SOLUTIONS.reduce((acc, sol) => ({
 warmUpContext();
 
 const SOLUTION_FNS = SOLUTIONS.reduce((acc, sol) => {
-  const code = fs.readFileSync(`${SOLUTIONS_DIR}/${sol}`, { encoding:'utf8', flag: 'r' });
+  const code = `(()=>{
+    ${fs.readFileSync(`${SOLUTIONS_DIR}/${sol}`, { encoding:'utf8', flag: 'r' })}
+  })()`;
   let fn = () => {};
   const context = { module: { exports: {}}};
   vm.createContext(context);


### PR DESCRIPTION
Change the evaluator so it wraps a solution's `code` in an IIFE before running it in a vm context. This fixes the issue where function declarations (e.g. `function foo () {}`), which are not actually global in node, "escape" the vm context and are counted as global so that the solution is incorrectly marked as `onlyCodeGolf`. See [this slack thread](https://passionatepeople.slack.com/archives/C01QBNFUQRJ/p1620913419264400).

Side note: this change doesn't affect code golf sizes, as those are retrieved separately via `stat`.